### PR TITLE
feat: add option to start application minimized

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@
 
 See the [Releases](https://github.com/tomsquest/fynodoro/releases) section on GitHub.
 
+## Usage
+
+```shell
+fynodoro              # Start normally
+fynodoro --minimized  # Start minimized to system tray
+```
+
 ## Configuration
 
 The Pomodoro technique defaults to 4 work rounds of 25 minutes, with a 5 minutes pause ("short break") in-between and a final 15 minutes pause (the "long" break), for a total of 2 hours (4x25m Work + 3x5m Short breaks + 1x15m Long break).
@@ -70,6 +77,8 @@ You can **disable** Long breaks by setting the duration of Long breaks to `0` or
 You can **disable** Short breaks by setting the duration of Short breaks to `0`. This will make the timer do a Work period, then a Long break, and so-on, and never do Short break.
 
 Tips: you can **disable** both Short and Long breaks by setting them to `0`. The timer will then act as a ticker, notifying you after each Work period.
+
+You can **start minimized** to the system tray by enabling the option in Settings, or by using the `--minimized` command-line flag.
 
 ### Notification sound
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,8 @@
 package main
 
 import (
+	"flag"
+
 	"fyne.io/fyne/v2/app"
 	"github.com/tomsquest/fynodoro/ui"
 )
@@ -14,9 +16,13 @@ var (
 	commitDate string
 )
 
+var startMinimized = flag.Bool("minimized", false, "Start the application minimized to tray")
+
 func main() {
+	flag.Parse()
+
 	myApp := app.NewWithID("com.tomsquest.fynodoro")
 	myApp.SetIcon(ui.AssetIconPng)
 
-	ui.Display(myApp, ui.BuildInfo{version, commit, commitDate})
+	ui.Display(myApp, ui.BuildInfo{version, commit, commitDate}, *startMinimized)
 }

--- a/pref/pref.go
+++ b/pref/pref.go
@@ -9,6 +9,7 @@ type Pref struct {
 	ShortBreakDuration int
 	LongBreakDuration  int
 	WorkRounds         int
+	StartMinimized     bool
 }
 
 func Load() Pref {
@@ -18,6 +19,7 @@ func Load() Pref {
 		ShortBreakDuration: app.Preferences().IntWithFallback("shortBreakDuration", 5),
 		LongBreakDuration:  app.Preferences().IntWithFallback("longBreakDuration", 15),
 		WorkRounds:         app.Preferences().IntWithFallback("workRounds", 4),
+		StartMinimized:     app.Preferences().BoolWithFallback("startMinimized", false),
 	}
 }
 
@@ -27,4 +29,5 @@ func Save(pref Pref) {
 	app.Preferences().SetInt("shortBreakDuration", pref.ShortBreakDuration)
 	app.Preferences().SetInt("longBreakDuration", pref.LongBreakDuration)
 	app.Preferences().SetInt("workRounds", pref.WorkRounds)
+	app.Preferences().SetBool("startMinimized", pref.StartMinimized)
 }

--- a/ui/settings.go
+++ b/ui/settings.go
@@ -74,17 +74,24 @@ func makeForm() *widget.Form {
 	_ = workRoundsBinding.Set(myPref.WorkRounds)
 	form.AppendItem(newIntegerFormItem(workRoundsBinding, "Work rounds", "Set how many Work rounds before a long break. Default is: %d. 0 to disable.", NewRangeValidator(0, 999)))
 
+	startMinimizedBinding := binding.NewBool()
+	_ = startMinimizedBinding.Set(myPref.StartMinimized)
+	startMinimizedCheck := widget.NewCheckWithData("Start minimized to tray", startMinimizedBinding)
+	form.AppendItem(widget.NewFormItem("", startMinimizedCheck))
+
 	form.OnSubmit = func() {
 		workDuration, _ := workDurationBinding.Get()
 		shortBreakDuration, _ := shortBreakDurationBinding.Get()
 		longBreakDuration, _ := longBreakDurationBinding.Get()
 		workRounds, _ := workRoundsBinding.Get()
+		startMinimized, _ := startMinimizedBinding.Get()
 
 		newPref := pref.Pref{
-			workDuration,
-			shortBreakDuration,
-			longBreakDuration,
-			workRounds,
+			WorkDuration:       workDuration,
+			ShortBreakDuration: shortBreakDuration,
+			LongBreakDuration:  longBreakDuration,
+			WorkRounds:         workRounds,
+			StartMinimized:     startMinimized,
 		}
 		pref.Save(newPref)
 	}

--- a/ui/settings.go
+++ b/ui/settings.go
@@ -77,7 +77,7 @@ func makeForm() *widget.Form {
 	startMinimizedBinding := binding.NewBool()
 	_ = startMinimizedBinding.Set(myPref.StartMinimized)
 	startMinimizedCheck := widget.NewCheckWithData("Start minimized to tray", startMinimizedBinding)
-	form.AppendItem(widget.NewFormItem("", startMinimizedCheck))
+	form.AppendItem(widget.NewFormItem("Startup", startMinimizedCheck))
 
 	form.OnSubmit = func() {
 		workDuration, _ := workDurationBinding.Get()

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -19,7 +19,7 @@ type BuildInfo struct {
 	CommitDate string
 }
 
-func Display(app fyne.App, buildInfo BuildInfo) {
+func Display(app fyne.App, buildInfo BuildInfo, cliStartMinimized bool) {
 	myPref := pref.Load()
 	thePomodoro := pomodoro.NewPomodoro(&pomodoro.Params{
 		WorkDuration:       time.Duration(myPref.WorkDuration) * time.Minute,
@@ -44,7 +44,11 @@ func Display(app fyne.App, buildInfo BuildInfo) {
 		desk.SetSystemTrayMenu(trayMenu)
 	}
 
-	mainWindow.ShowAndRun()
+	if cliStartMinimized || myPref.StartMinimized {
+		app.Run()
+	} else {
+		mainWindow.ShowAndRun()
+	}
 }
 
 func makeAboutWindow(app fyne.App, buildInfo BuildInfo) fyne.Window {


### PR DESCRIPTION
## Summary
- Add `--minimized` CLI flag to start the app hidden to system tray
- Add "Start minimized to tray" checkbox in Settings dialog for persistent preference
- Either CLI flag or preference causes minimized startup (OR logic)

## Test plan
- [x] Run `fynodoro --minimized` and verify app starts with no visible window
- [x] Click tray icon "Show" to verify window appears correctly
- [x] Open Settings, enable "Start minimized to tray", restart app
- [x] Verify app starts minimized without CLI flag
- [x] Run `go test -v ./...` to verify all tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)