### PR TITLE
feat: add right-click context menu to timer

### DIFF
--- a/ui/tappable_text.go
+++ b/ui/tappable_text.go
@@ -10,8 +10,9 @@ import (
 
 type TappableText struct {
 	widget.BaseWidget
-	Label    *canvas.Text
-	OnTapped func()
+	Label             *canvas.Text
+	OnTapped          func()
+	OnTappedSecondary func(*fyne.PointEvent)
 }
 
 func NewTappableText(title string, color color.Color, tapped func()) *TappableText {
@@ -30,6 +31,12 @@ func (t *TappableText) CreateRenderer() fyne.WidgetRenderer {
 func (t *TappableText) Tapped(*fyne.PointEvent) {
 	if onTapped := t.OnTapped; onTapped != nil {
 		onTapped()
+	}
+}
+
+func (t *TappableText) TappedSecondary(pe *fyne.PointEvent) {
+	if onTappedSecondary := t.OnTappedSecondary; onTappedSecondary != nil {
+		onTappedSecondary(pe)
 	}
 }
 


### PR DESCRIPTION
- Add OnTappedSecondary support to TappableText widget to handle right-clicks
- Implement timer context menu with all available actions:
  * Play/Pause (with dynamic label based on timer state)
  * Stop
  * Next
  * Settings
  * Close (hide to tray)
  * Quit (exit application)
- Add Quit option to system tray menu
- Left-click continues to toggle play/pause as before
- Prepares for future layouts where buttons may be hidden