### PR TITLE
feat: add Quit entry to tray menu

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -40,7 +40,8 @@ func Display(app fyne.App, buildInfo BuildInfo, cliStartMinimized bool) {
 			fyne.NewMenuItem("Show", mainWindow.Show),
 			fyne.NewMenuItem("Hide", mainWindow.Hide),
 			fyne.NewMenuItem("Center", mainWindow.CenterOnScreen),
-			fyne.NewMenuItem("About", aboutWindow.Show))
+			fyne.NewMenuItem("About", aboutWindow.Show),
+			fyne.NewMenuItem("Quit", app.Quit))
 		desk.SetSystemTrayMenu(trayMenu)
 	}
 


### PR DESCRIPTION
Add Quit menu item to system tray that properly exits the application.
This complements the existing Hide option, giving users a clear way to
either hide the window to tray or completely quit the application.