### PR TITLE
feat: add notification customization options

### DIFF
--- a/pref/pref.go
+++ b/pref/pref.go
@@ -5,21 +5,25 @@ import (
 )
 
 type Pref struct {
-	WorkDuration       int
-	ShortBreakDuration int
-	LongBreakDuration  int
-	WorkRounds         int
-	StartMinimized     bool
+	WorkDuration            int
+	ShortBreakDuration      int
+	LongBreakDuration       int
+	WorkRounds              int
+	StartMinimized          bool
+	EnableNotificationPopup bool
+	NotificationScript      string
 }
 
 func Load() Pref {
 	app := fyne.CurrentApp()
 	return Pref{
-		WorkDuration:       app.Preferences().IntWithFallback("workDuration", 25),
-		ShortBreakDuration: app.Preferences().IntWithFallback("shortBreakDuration", 5),
-		LongBreakDuration:  app.Preferences().IntWithFallback("longBreakDuration", 15),
-		WorkRounds:         app.Preferences().IntWithFallback("workRounds", 4),
-		StartMinimized:     app.Preferences().BoolWithFallback("startMinimized", false),
+		WorkDuration:            app.Preferences().IntWithFallback("workDuration", 25),
+		ShortBreakDuration:      app.Preferences().IntWithFallback("shortBreakDuration", 5),
+		LongBreakDuration:       app.Preferences().IntWithFallback("longBreakDuration", 15),
+		WorkRounds:              app.Preferences().IntWithFallback("workRounds", 4),
+		StartMinimized:          app.Preferences().BoolWithFallback("startMinimized", false),
+		EnableNotificationPopup: app.Preferences().BoolWithFallback("enableNotificationPopup", true),
+		NotificationScript:      app.Preferences().StringWithFallback("notificationScript", "/usr/share/fynodoro/notify.sh"),
 	}
 }
 
@@ -30,4 +34,6 @@ func Save(pref Pref) {
 	app.Preferences().SetInt("longBreakDuration", pref.LongBreakDuration)
 	app.Preferences().SetInt("workRounds", pref.WorkRounds)
 	app.Preferences().SetBool("startMinimized", pref.StartMinimized)
+	app.Preferences().SetBool("enableNotificationPopup", pref.EnableNotificationPopup)
+	app.Preferences().SetString("notificationScript", pref.NotificationScript)
 }

--- a/ui/notify.go
+++ b/ui/notify.go
@@ -4,21 +4,27 @@ import (
 	"fmt"
 	"github.com/gen2brain/beeep"
 	"github.com/tomsquest/fynodoro/pomodoro"
+	"github.com/tomsquest/fynodoro/pref"
 	"log"
 	"os/exec"
 )
 
 func notifyPomodoroDone(kind pomodoro.Kind) {
-	title := fmt.Sprintf("%s done", kind)
-	content := fmt.Sprintf("You just finished a %s pomodoro.", kind)
-	err := beeep.Notify(title, content, "/usr/share/pixmaps/fynodoro.png")
-	if err != nil {
-		log.Printf("unable to display notification bubble: %v\n", err)
+	myPref := pref.Load()
+
+	if myPref.EnableNotificationPopup {
+		title := fmt.Sprintf("%s done", kind)
+		content := fmt.Sprintf("You just finished a %s pomodoro.", kind)
+		err := beeep.Notify(title, content, "/usr/share/pixmaps/fynodoro.png")
+		if err != nil {
+			log.Printf("unable to display notification bubble: %v\n", err)
+		}
 	}
 
-	script := "/home/tom/Dev/fynodoro/assets/notify.sh"
-	cmd := exec.Command("/bin/sh", script)
-	if err := cmd.Run(); err != nil {
-		log.Printf("unable to run script: %v\n", err)
+	if myPref.NotificationScript != "" {
+		cmd := exec.Command("/bin/sh", myPref.NotificationScript)
+		if err := cmd.Run(); err != nil {
+			log.Printf("unable to run script: %v\n", err)
+		}
 	}
 }

--- a/ui/settings.go
+++ b/ui/settings.go
@@ -79,19 +79,36 @@ func makeForm() *widget.Form {
 	startMinimizedCheck := widget.NewCheckWithData("Start minimized to tray", startMinimizedBinding)
 	form.AppendItem(widget.NewFormItem("Startup", startMinimizedCheck))
 
+	enableNotificationPopupBinding := binding.NewBool()
+	_ = enableNotificationPopupBinding.Set(myPref.EnableNotificationPopup)
+	enableNotificationPopupCheck := widget.NewCheckWithData("Enable notification popup", enableNotificationPopupBinding)
+	form.AppendItem(widget.NewFormItem("Notification popup", enableNotificationPopupCheck))
+
+	notificationScriptBinding := binding.NewString()
+	_ = notificationScriptBinding.Set(myPref.NotificationScript)
+	notificationScriptEntry := widget.NewEntryWithData(notificationScriptBinding)
+	notificationScriptEntry.PlaceHolder = "Path to notification script (empty to disable)"
+	notificationScriptFormItem := widget.NewFormItem("Notification script", notificationScriptEntry)
+	notificationScriptFormItem.HintText = "Path to a script to run when a pomodoro ends. Leave empty to disable. Default: /usr/share/fynodoro/notify.sh"
+	form.AppendItem(notificationScriptFormItem)
+
 	form.OnSubmit = func() {
 		workDuration, _ := workDurationBinding.Get()
 		shortBreakDuration, _ := shortBreakDurationBinding.Get()
 		longBreakDuration, _ := longBreakDurationBinding.Get()
 		workRounds, _ := workRoundsBinding.Get()
 		startMinimized, _ := startMinimizedBinding.Get()
+		enableNotificationPopup, _ := enableNotificationPopupBinding.Get()
+		notificationScript, _ := notificationScriptBinding.Get()
 
 		newPref := pref.Pref{
-			WorkDuration:       workDuration,
-			ShortBreakDuration: shortBreakDuration,
-			LongBreakDuration:  longBreakDuration,
-			WorkRounds:         workRounds,
-			StartMinimized:     startMinimized,
+			WorkDuration:            workDuration,
+			ShortBreakDuration:      shortBreakDuration,
+			LongBreakDuration:       longBreakDuration,
+			WorkRounds:              workRounds,
+			StartMinimized:          startMinimized,
+			EnableNotificationPopup: enableNotificationPopup,
+			NotificationScript:      notificationScript,
 		}
 		pref.Save(newPref)
 	}


### PR DESCRIPTION
Add two new options to customize notifications:
- Option to enable/disable notification popup (enabled by default)
- Option to change or disable notification script (path configurable, empty to disable)

This allows users to customize how they are notified when a pomodoro ends.