### PR TITLE
fix: wrap UI updates in fyne.Do for thread safety

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -127,13 +127,17 @@ func MakeClassicLayout(thePomodoro *pomodoro.Pomodoro) fyne.CanvasObject {
 	}
 
 	thePomodoro.OnTick = func() {
-		setTimerRemainingTime(thePomodoro, timer)
+		fyne.Do(func() {
+			setTimerRemainingTime(thePomodoro, timer)
+		})
 	}
 	thePomodoro.OnEnd = func(kind pomodoro.Kind) {
-		setTimerRemainingTime(thePomodoro, timer)
+		fyne.Do(func() {
+			setTimerRemainingTime(thePomodoro, timer)
 
-		playButton.Icon = theme.MediaPlayIcon()
-		playButton.Refresh()
+			playButton.Icon = theme.MediaPlayIcon()
+			playButton.Refresh()
+		})
 
 		notifyPomodoroDone(kind)
 	}


### PR DESCRIPTION
## Summary

- Wrap UI updates in `fyne.Do()` within `OnTick` and `OnEnd` callbacks
- Fixes thread safety warnings introduced in Fyne 2.6+

## Problem

The pomodoro ticker runs in a background goroutine and calls `OnTick`/`OnEnd` callbacks which modify UI widgets directly. Since Fyne 2.6, this triggers warnings:

```
*** Error in Fyne call thread, this should have been called in fyne.Do[AndWait] ***
  From: /home/tom/Dev/fynodoro/ui/tappable_text.go:38
  From: /home/tom/Dev/fynodoro/ui/ui.go:146
```

## Test plan

- [ ] Run the application and start a pomodoro timer
- [ ] Verify no thread safety warnings appear in the console
- [ ] Verify the timer updates correctly